### PR TITLE
Fix duplicate id property in project retrieval

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,10 @@ async function getRecentProjects(): Promise<Project[]> {
     limit(3)
   );
   const snapshot = await getDocs(q);
-  return snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Project) }));
+  return snapshot.docs.map((d) => {
+    const data = d.data() as Omit<Project, 'id'>;
+    return { ...data, id: d.id };
+  });
 }
 
 export default async function Home() {

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -25,7 +25,10 @@ export default function ProjectList() {
         )
       : query(collection(db, 'projects'), orderBy('createdAt', 'desc'), limit(PAGE_SIZE));
     const snapshot = await getDocs(q);
-    const docs = snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Project) }));
+    const docs = snapshot.docs.map((d) => {
+      const data = d.data() as Omit<Project, 'id'>;
+      return { ...data, id: d.id };
+    });
     setProjects((prev) => [...prev, ...docs]);
     const lastVisible = snapshot.docs[snapshot.docs.length - 1] ?? null;
     setLastDoc(lastVisible);


### PR DESCRIPTION
## Summary
- prevent TypeScript error by excluding `id` field from Firestore data when assembling project objects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b30ed62ee8832486f6fa67eb46b634